### PR TITLE
Add missing dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ features = ["winerror", "ioapiset", "minwinbase", "winbase"]
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }
 rand = "0.4"
+mio = "0.6.5"


### PR DESCRIPTION
```
❯ cargo test
   Compiling rand v0.4.2
   Compiling env_logger v0.4.3
   Compiling mio-named-pipes v0.1.5 (file:///home/hugh/tmp/mio-named-pipes)
error[E0463]: can't find crate for `mio`
 --> tests/smoke.rs:1:1
  |
1 | extern crate mio;
  | ^^^^^^^^^^^^^^^^^ can't find crate

error: aborting due to previous error

For more information about this error, try `rustc --explain E0463`.
error: Could not compile `mio-named-pipes`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```