### PR TITLE
Pool read/write buffers.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,8 @@ struct Inner {
     write: windows::Overlapped,
 
     io: Mutex<Io>,
+
+    pool: Mutex<BufferPool>,
 }
 
 struct Io {
@@ -316,6 +318,7 @@ impl<'a> Read for &'a NamedPipe {
                 if next != data.len() {
                     state.read = State::Ok(data, next);
                 } else {
+                    self.inner.put_buffer(data);
                     Inner::schedule_read(&self.inner, &mut state);
                 }
                 Ok(n)
@@ -350,9 +353,9 @@ impl<'a> Write for &'a NamedPipe {
         }
 
         // Move `buf` onto the heap and fire off the write
-        //
-        // TODO: need to be smarter about buffer management here
-        Inner::schedule_write(&self.inner, buf.to_vec(), 0, &mut io);
+        let mut owned_buf = self.inner.get_buffer();
+        owned_buf.extend(buf);
+        Inner::schedule_write(&self.inner, owned_buf, 0, &mut io);
         Ok(buf.len())
     }
 
@@ -438,6 +441,7 @@ impl FromRawHandle for NamedPipe {
                     write: State::None,
                     connect_error: None,
                 }),
+                pool: Mutex::new(BufferPool::with_capacity(2)),
             }),
         }
     }
@@ -489,9 +493,7 @@ impl Inner {
                     .expect("event loop seems gone");
 
         // Allocate a buffer and schedule the read.
-        //
-        // TODO: need to be smarter about buffer management here
-        let mut buf = Vec::with_capacity(8 * 1024);
+        let mut buf = me.get_buffer();
         let e = unsafe {
             let overlapped = me.read.as_mut_ptr() as *mut _;
             let slice = slice::from_raw_parts_mut(buf.as_mut_ptr(),
@@ -567,6 +569,14 @@ impl Inner {
                 me.add_readiness(Ready::writable());
             }
         }
+    }
+
+    fn get_buffer(&self) -> Vec<u8> {
+        self.pool.lock().unwrap().get(8 * 1024)
+    }
+
+    fn put_buffer(&self, buf: Vec<u8>) {
+        self.pool.lock().unwrap().put(buf)
     }
 }
 
@@ -668,6 +678,7 @@ fn write_done(status: &OVERLAPPED_ENTRY) {
                 debug_assert_eq!(status.bytes_transferred() as usize, n);
                 let new_pos = pos + (status.bytes_transferred() as usize);
                 if new_pos == buf.len() {
+                    me.put_buffer(buf);
                     me.add_readiness(Ready::writable());
                 } else {
                     Inner::schedule_write(&me, buf, new_pos, &mut io);
@@ -678,6 +689,30 @@ fn write_done(status: &OVERLAPPED_ENTRY) {
                 io.write = State::Err(e);
                 me.add_readiness(Ready::writable());
             }
+        }
+    }
+}
+
+// Based on https://github.com/tokio-rs/mio/blob/13d5fc9/src/sys/windows/buffer_pool.rs
+struct BufferPool {
+    pool: Vec<Vec<u8>>,
+}
+
+impl BufferPool {
+    fn with_capacity(cap: usize) -> BufferPool {
+        BufferPool {
+            pool: Vec::with_capacity(cap),
+        }
+    }
+
+    fn get(&mut self, default_cap: usize) -> Vec<u8> {
+        self.pool.pop().unwrap_or_else(|| Vec::with_capacity(default_cap))
+    }
+
+    fn put(&mut self, mut buf: Vec<u8>) {
+        if self.pool.len() < self.pool.capacity() {
+            unsafe { buf.set_len(0); }
+            self.pool.push(buf);
         }
     }
 }


### PR DESCRIPTION
Add a small Vec<u8> buffer pool to avoid allocations when buffers can be reused.  Based on [mio 0.6's](https://github.com/tokio-rs/mio/blob/13d5fc9/src/sys/windows/buffer_pool.rs) internal BufferPool.

It seems like it'd be better to share mio's existing BufferPool on the IOCP Selector but it's not public, so using a small pool internally on the NamedPipe seems like the simplest approach for now.