### PR TITLE
Update mio 0.6 -> 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ Windows named pipe bindings for mio.
 
 [target.'cfg(windows)'.dependencies]
 log = "0.4"
-mio = "0.6.5"
+mio = "0.7"
 miow = "0.3"
 
 [target.'cfg(windows)'.dependencies.winapi]


### PR DESCRIPTION
This one causes duplicate versions of `miow` to appear in the dependency tree. @alexcrichton would be grateful if this was updated.

![image](https://user-images.githubusercontent.com/36276403/81221539-a8c83100-8feb-11ea-8423-5fa4e4cf4204.png)

(generated via [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny))